### PR TITLE
Change external dependency to rhds jupyterhub-singleuser-profiles

### DIFF
--- a/requirements-external.txt
+++ b/requirements-external.txt
@@ -1,3 +1,3 @@
 git+https://github.com/opendatahub-io/oauthenticator@2bf137c35e4eddac0a586ac054098ff74c30c779#egg=oauthenticator
 git+https://github.com/vpavlin/jupyter-publish-extension@7cbf34e494fd9a0a79e9cd9a8c1d48a6775b9f49#egg=publish-service
-git+https://github.com/tmckayus/jupyterhub-singleuser-profiles@25c4cab3e767118f17678a9d896d2a820f76c206#egg=jupyterhub-singleuser-profiles
+git+https://github.com/red-hat-data-services/jupyterhub-singleuser-profiles@25d6b4501df724f74f5218fc628c7db4e5bd69c8#egg=jupyterhub-singleuser-profiles


### PR DESCRIPTION
Transferred ownership of repositories from tmckayus to rhds