### PR TITLE
Update jupyterhub-singleuser-profiles to v0.2.2

### DIFF
--- a/requirements-external.txt
+++ b/requirements-external.txt
@@ -1,3 +1,3 @@
 git+https://github.com/opendatahub-io/oauthenticator@2bf137c35e4eddac0a586ac054098ff74c30c779#egg=oauthenticator
 git+https://github.com/vpavlin/jupyter-publish-extension@7cbf34e494fd9a0a79e9cd9a8c1d48a6775b9f49#egg=publish-service
-git+https://github.com/red-hat-data-services/jupyterhub-singleuser-profiles@25d6b4501df724f74f5218fc628c7db4e5bd69c8#egg=jupyterhub-singleuser-profiles
+git+https://github.com/red-hat-data-services/jupyterhub-singleuser-profiles@8527cf8f8f8e2e64d61e2b2fc401c03446a5e8d1#egg=jupyterhub-singleuser-profiles


### PR DESCRIPTION
This updates the requirements-external.txt file to point to the hash for v0.2.2 of jupyterhub-singleuser-profiles


## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [ X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

… Explain your changes.

## Description

<!--- Describe your changes in detail -->
