### PR TITLE
[UPSTREAM] Update s2i assembly to support multiple template html files

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -24,6 +24,6 @@ mkdir jsp-ui
 cp -a ${JSP_UI_SRC_PATH}/build/. /opt/app-root/share/jupyterhub/static/jsp-ui
 
 cd ${JSP_UI_SRC_PATH}/templates/
-yes | cp -rf spawn.html /opt/app-root/share/jupyterhub/templates/
+yes | cp -rf *.html /opt/app-root/share/jupyterhub/templates/
 
 fix-permissions /opt/app-root


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHODS-1889
Cherry-pick of https://github.com/opendatahub-io/jupyterhub-odh/pull/121

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1889
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
