### PR TITLE
[UPSTREAM] Get image directly during pre-spawn, instead of using form.

### DIFF
--- a/.jupyter/jupyterhub_config.py
+++ b/.jupyter/jupyterhub_config.py
@@ -246,6 +246,8 @@ class OpenShiftSpawner(KubeSpawner):
 
     return url
 
+  def get_image(self):
+    return self.single_user_profiles.user.get(self.user.name)['last_selected_image']
 
 def apply_pod_profile(spawner, pod):
   spawner.single_user_profiles.load_profiles(username=spawner.user.name)
@@ -254,6 +256,7 @@ def apply_pod_profile(spawner, pod):
   return SingleuserProfiles.apply_pod_profile(spawner.user.name, pod, profile, gpu_types, DEFAULT_MOUNT_PATH, spawner.gpu_mode)
 
 def setup_environment(spawner):
+    spawner.image = spawner.get_image()
     spawner.single_user_profiles.load_profiles(username=spawner.user.name)
     spawner.single_user_profiles.setup_services(spawner, spawner.image, spawner.user.name)
 


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2240
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Testing:
1. Deploy modified jupyterhub-odh and latest JSP master (has to include the new modal spawn progress window) on cluster.
2. Attempt spawning any image.
3. Notebook server should start.
