### PR TITLE
Force jupyterhub to be lower than 2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 aiohttp
 escapism
-jupyterhub>=1.2
+jupyterhub>=1.2,<2.0
 passlib
 toml
 kubernetes


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2240
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Related to #65 
