### PR TITLE
Reduce waiting time to avoid downtime

### DIFF
--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -16,7 +16,7 @@ wait_service
 echo "Waiting to become leader..."
 
 until [ "${ME}" == "$(get_leader)" ]; do
-  sleep 6
+  sleep 3
 done
 
 echo "Assigned as new leader"


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-2440
- [X] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
——
**Testing Instructions**

1. Install a base version of rhods (tested with quay.io/modh/qe-catalog-source:v190-7).
2. Install a new version with the following image: quay.io/lferrnan/rhods-operator-live-catalog:1.9.9-1-jupyterhub-downtime.
3. The downtime of jupyterhub should be less than 1 minute and the pods of the old replicaset should be killed instantly.